### PR TITLE
Move const to the RHS of the function (issue 12931)

### DIFF
--- a/source/xlld/wrap/worksheet.d
+++ b/source/xlld/wrap/worksheet.d
@@ -107,7 +107,7 @@ struct WorksheetFunction {
             ] ~ argumentHelp.value;
     }
 
-    const bool opEquals(const WorksheetFunction rhs) @safe pure { return optional == rhs.optional; }
+    bool opEquals(const WorksheetFunction rhs) const @safe pure { return optional == rhs.optional; }
 }
 
 // helper template to type-check variadic template constructor below


### PR DESCRIPTION
This isn't deprecated yet, but there's a DMD PR for it.