### PR TITLE
Remove invalid return scope lambda

### DIFF
--- a/source/xlld/sdk/framework.d
+++ b/source/xlld/sdk/framework.d
@@ -122,7 +122,7 @@ int Excel12f(int xlfn, LPXLOPER12 result, scope const(XLOPER12)[] args...) nothr
     scope(exit) Mallocator.instance.dispose(ptrArgs);
 
     foreach(i, ref arg; args)
-        ptrArgs[i] = (return scope ref const(XLOPER12) a) { return &a; }(arg);
+        ptrArgs[i] = &arg;
 
     return Excel12f(xlfn, result, ptrArgs);
 }


### PR DESCRIPTION
Needed for https://github.com/dlang/dmd/pull/12665#issuecomment-858836483
I don't know why this immediately called lambda pattern was used, it seems to do fine without and it's `@system` code anyway. It would need to be `@trusted` in order to be called from `@safe` code since it frees manually.