### PR TITLE
Unblock dip1000 pure-scope fix in dmd

### DIFF
--- a/source/xlld/conv/to.d
+++ b/source/xlld/conv/to.d
@@ -322,7 +322,7 @@ XLOPER12 toXlOper(T, A)(T value, ref A allocator)
     import std.conv: text;
     import core.memory: GC;
 
-    scope str = text(value);
+    auto str = text(value);
 
     auto ret = str.toXlOper(allocator);
     () @trusted { GC.free(cast(void*)str.ptr); }();

--- a/tests/ut/wrap/traits.d
+++ b/tests/ut/wrap/traits.d
@@ -55,7 +55,7 @@ WorksheetFunction asyncFunction(wstring name) @safe pure nothrow {
 
 ///
 @("getWorksheetFunction for double -> double functions with no extra attributes")
-@safe pure unittest {
+@system pure unittest {
     extern(Windows) double foo(double n) nothrow @nogc { return 0; }
     getWorksheetFunction!foo.shouldEqual(doubleToDoubleFunction("foo"));
 
@@ -72,7 +72,7 @@ WorksheetFunction asyncFunction(wstring name) @safe pure nothrow {
 
 ///
 @("getworksheetFunction with @Register in order")
-@safe pure unittest {
+@system pure unittest {
 
     @Register(ArgumentText("my arg txt"), MacroType("macro"))
     extern(Windows) double foo(double) nothrow;
@@ -86,7 +86,7 @@ WorksheetFunction asyncFunction(wstring name) @safe pure nothrow {
 
 ///
 @("getworksheetFunction with @Register out of order")
-@safe pure unittest {
+@system pure unittest {
 
     @Register(HelpTopic("I need somebody"), ArgumentText("my arg txt"))
     extern(Windows) double foo(double) nothrow;
@@ -100,7 +100,7 @@ WorksheetFunction asyncFunction(wstring name) @safe pure nothrow {
 
 
 @("getWorksheetFunction with @ExcelParameter")
-@safe pure unittest {
+@system pure unittest {
     extern(Windows) double withParamUDA(@ExcelParameter("the double") double d) nothrow;
 
     auto expected = doubleToDoubleFunction("withParamUDA");
@@ -136,7 +136,7 @@ WorksheetFunction asyncFunction(wstring name) @safe pure nothrow {
 
 
 @("getWorksheetFunctions on test.xl_funcs")
-@safe pure unittest {
+@system pure unittest {
     getModuleWorksheetFunctions!"test.xl_funcs".shouldEqual(
         [
             doubleToDoubleFunction("FuncMulByTwo"),


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/12989 fails because of buildkite errors in this project. Marking the unittests `@system` is a stopgap, it would be better to fix `shouldEqual` in unit-threaded, but that's a generic template function which makes it much harder to fix.